### PR TITLE
fix: ordering of logic on retry of load config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-zitadel-auth"
-version = "0.2.4"  # change in src/fastapi_zitadel_auth/__init__.py as well
+version = "0.2.5"  # change in src/fastapi_zitadel_auth/__init__.py as well
 description = "Zitadel authentication for FastAPI"
 readme = "README.md"
 authors = [

--- a/src/fastapi_zitadel_auth/__init__.py
+++ b/src/fastapi_zitadel_auth/__init__.py
@@ -4,6 +4,6 @@ FastAPI Zitadel Auth
 
 from fastapi_zitadel_auth.auth import ZitadelAuth
 
-__version__ = "0.2.4"  # remember to update also in pyproject.toml
+__version__ = "0.2.5"  # remember to update also in pyproject.toml
 
 __all__ = ["ZitadelAuth", "__version__"]

--- a/src/fastapi_zitadel_auth/openid_config.py
+++ b/src/fastapi_zitadel_auth/openid_config.py
@@ -64,9 +64,9 @@ class OpenIdConfig(BaseModel):
         """Get a signing key by its ID, refreshing JWKS once if necessary."""
         if kid not in self.signing_keys:
             log.debug("Key '%s' not found, refreshing JWKS", kid)
+            await self._sleep()
             self.reset_cache()
             await self.load_config()
-            await self._sleep()
 
             if kid not in self.signing_keys:
                 log.error(f"Unable to verify token, no signing keys found for key with ID: '{kid}'")

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-zitadel-auth"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
we want to sleep first before retrying the config to wait on Zitadel to generate the (public) key, not after.