### PR TITLE
fix: authorize scopes only on verified token claims (#148)

### DIFF
--- a/src/fastapi_zitadel_auth/auth.py
+++ b/src/fastapi_zitadel_auth/auth.py
@@ -184,8 +184,8 @@ class ZitadelAuth(SecurityBase):
                 raise UnauthorizedException("Unable to process token") from error
 
             else:
-                # Authorize only on verified claims (fix for #148).
                 self.token_validator.validate_scopes(verified_claims, security_scopes.scopes)
+
                 user: UserT = self.user_model(  # type: ignore
                     claims=self.claims_model.model_validate(verified_claims),
                     access_token=access_token,

--- a/src/fastapi_zitadel_auth/auth.py
+++ b/src/fastapi_zitadel_auth/auth.py
@@ -147,9 +147,7 @@ class ZitadelAuth(SecurityBase):
             if access_token is None:
                 raise UnauthorizedException("No access token provided")
 
-            unverified_header, unverified_claims = self.token_validator.parse_unverified_token(access_token)
-            self.token_validator.validate_header(unverified_header)
-            self.token_validator.validate_scopes(unverified_claims, security_scopes.scopes)
+            unverified_header = self.token_validator.parse_and_validate_header(access_token)
 
             await self.openid_config.load_config()
             signing_key = await self.openid_config.get_key(unverified_header["kid"])
@@ -186,6 +184,8 @@ class ZitadelAuth(SecurityBase):
                 raise UnauthorizedException("Unable to process token") from error
 
             else:
+                # Authorize only on verified claims (fix for #148).
+                self.token_validator.validate_scopes(verified_claims, security_scopes.scopes)
                 user: UserT = self.user_model(  # type: ignore
                     claims=self.claims_model.model_validate(verified_claims),
                     access_token=access_token,

--- a/src/fastapi_zitadel_auth/token.py
+++ b/src/fastapi_zitadel_auth/token.py
@@ -35,14 +35,10 @@ class TokenValidator:
         return True
 
     @staticmethod
-    def parse_unverified_token(
-        access_token: str,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Parse header and claims without verification"""
+    def parse_and_validate_header(access_token: str) -> dict[str, Any]:
+        """Parse the JWT header and check `alg`/`typ` without verifying the signature"""
         try:
             header = dict(jwt.get_unverified_header(access_token))
-            claims = dict(jwt.decode(access_token, options={"verify_signature": False}))
-            return header, claims
         except Exception as e:
             log.warning(
                 "Malformed token received. %s. Error: %s",
@@ -52,11 +48,10 @@ class TokenValidator:
             )
             raise UnauthorizedException("Invalid token format") from e
 
-    @staticmethod
-    def validate_header(header: dict[str, Any]) -> None:
-        """Validate token header"""
         if header.get("alg") != "RS256" or header.get("typ") != "JWT":
             raise UnauthorizedException("Invalid token header")
+
+        return header
 
     @staticmethod
     def verify(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -299,6 +299,23 @@ async def test_exception_handled(fastapi_app, mock_openid_and_keys, mocker):
         assert response.headers["WWW-Authenticate"] == "Bearer"
 
 
+async def test_invalid_signature_does_not_leak_scope_requirement(fastapi_app, mock_openid_and_keys):
+    """Regression for #148: an unauthenticated forgery with scope claims must
+    return 401 (signature failure) and must not disclose the route's
+    required scope in the response body."""
+    forged = create_test_token(scopes="not-the-real-scope", evil=True)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {forged}"},
+    ) as ac:
+        response = await ac.get("/api/protected/scope")
+    assert response.status_code == 401
+    body = response.text
+    assert "Missing required scope" not in body
+    assert "scope1" not in body
+
+
 async def test_refresh_config_on_unknown_key_id(fastapi_app, mock_openid_empty_then_ok, mocker):
     """Test that the OpenID configuration is refreshed if the key ID is initially not found."""
     sleep_mock = mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -131,28 +131,20 @@ class TestTokenValidator:
         claims = {"scope": scope_string}
         assert TokenValidator.validate_scopes(claims, [required_scope]) is True
 
-    def test_parse_unverified_valid_token(self, token_validator, valid_token):
+    def test_parse_and_validate_header_valid_token(self, token_validator, valid_token):
         """
-        Test that the TokenValidator can parse an unverified token
+        Test that the TokenValidator can parse the header of an unverified token
         """
-        header, claims = token_validator.parse_unverified_token(valid_token)
+        header = token_validator.parse_and_validate_header(valid_token)
 
         assert isinstance(header, dict)
-        assert isinstance(claims, dict)
         assert header["kid"] == "test-key-1"
         assert header["alg"] == "RS256"
-        assert claims["sub"] == "user123"
-        assert "exp" in claims
-        assert "iat" in claims
-        assert "iss" in claims
-        assert "aud" in claims
-        assert "nbf" in claims
-        assert "jti" in claims
 
-    def test_parse_unverified_none_token(self, token_validator):
+    def test_parse_and_validate_header_none_token(self, token_validator):
         """Test that the TokenValidator raises an exception when parsing a None token"""
         with pytest.raises(UnauthorizedException, match="Invalid token format"):
-            token_validator.parse_unverified_token(None)  # type: ignore
+            token_validator.parse_and_validate_header(None)  # type: ignore
 
     @pytest.mark.parametrize(
         "invalid_token",
@@ -173,10 +165,10 @@ class TestTokenValidator:
             "none_value",
         ],
     )
-    def test_parse_unverified_invalid_token(self, token_validator, invalid_token):
+    def test_parse_and_validate_header_invalid_token(self, token_validator, invalid_token):
         """Test that the TokenValidator raises an exception when parsing an invalid token"""
         with pytest.raises(UnauthorizedException, match="Invalid token format"):
-            token_validator.parse_unverified_token(invalid_token)
+            token_validator.parse_and_validate_header(invalid_token)
 
     def test_verify_valid_token(self, token_validator, valid_token, rsa_keys):
         """Test that the TokenValidator can verify a valid token"""


### PR DESCRIPTION
Closes #148


  - validate_scopes now runs on verified claims (after jwt.decode), not on the unverified payload.
  - TokenValidator no longer exposes any path returning unverified claims: parse_unverified_token + validate_header → single parse_and_validate_header.
  - Adds a regression test that a forged token with scope claims returns 401 and leaks no scope name.

Previously, unauthenticated callers could send a junk-signed JWT and read 403 "Missing required scope: <X>" to enumerate each route's required scope. Now signature failure short-circuits to 401 before any scope check runs.
