### PR TITLE
fix: harden JWKS refresh against unknown-kid DoS (#149)

### DIFF
--- a/src/fastapi_zitadel_auth/openid_config.py
+++ b/src/fastapi_zitadel_auth/openid_config.py
@@ -1,10 +1,30 @@
+"""
+OpenID Connect discovery and JWKS caching for Zitadel authentication.
+
+Two refresh paths share the same lock and signing-key cache:
+
+* ``load_config`` — periodic full refresh gated by ``cache_ttl_seconds``. The
+  JWKS endpoint is authoritative for currently-valid keys, so cached keys are
+  *replaced*; upstream-removed keys (e.g. after revocation) are evicted.
+
+* ``get_key`` — on-demand refresh triggered by an unknown ``kid`` from the
+  unverified token header. A 10 s cooldown bounds the per-window cost of
+  attacker-driven random-kid bursts to one sleep + one upstream GET. New keys
+  are *merged* so a sparse upstream response cannot wipe legitimate cached
+  keys held by in-flight requests.
+
+The 1 s pre-refresh sleep covers Zitadel's keypair propagation lag: signing
+keys are generated ad-hoc on token issuance, so JWKS may briefly lag behind
+a freshly-issued ``kid``.
+"""
+
 from asyncio import Lock, sleep
 from datetime import datetime, timedelta
 import logging
 from typing import Any
 import httpx
 from jwt import PyJWK
-from pydantic import BaseModel, ConfigDict, PositiveInt
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from fastapi_zitadel_auth.exceptions import UnauthorizedException
@@ -22,12 +42,13 @@ class OpenIdConfig(BaseModel):
     jwks_uri: str
     signing_keys: dict[str, RSAPublicKey] = {}
 
-    refresh_lock: Lock = Lock()
+    refresh_lock: Lock = Field(default_factory=Lock)
     last_refresh_timestamp: datetime | None = None
+    last_refresh_attempt: datetime | None = None
     cache_ttl_seconds: PositiveInt = 600
 
     async def load_config(self) -> None:
-        """Refresh the openid configuration and signing keys if necessary."""
+        """Refresh OIDC discovery and JWKS if the cache is empty or the TTL has elapsed."""
         async with self.refresh_lock:
             if not self._needs_refresh():
                 return
@@ -36,13 +57,13 @@ class OpenIdConfig(BaseModel):
             try:
                 async with httpx.AsyncClient(timeout=10, http2=True) as client:
                     config = await self._fetch_config(client)
-                    new_keys = await self._fetch_jwks(client)
+                    signing_keys = await self._fetch_signing_keys(client)
 
                 self.issuer_url = config["issuer"]
                 self.authorization_url = config["authorization_endpoint"]
                 self.token_url = config["token_endpoint"]
                 self.jwks_uri = config["jwks_uri"]
-                self.signing_keys = self._parse_jwks(new_keys)
+                self.signing_keys = signing_keys
                 self.last_refresh_timestamp = current_time
 
             except Exception as e:
@@ -60,32 +81,64 @@ class OpenIdConfig(BaseModel):
         log.debug("Cache TTL:           %s s", self.cache_ttl_seconds)
 
     async def get_key(self, kid: str) -> RSAPublicKey:
-        """Get a signing key by its ID, refreshing JWKS once if necessary."""
-        if kid not in self.signing_keys:
-            log.debug("Key '%s' not found, refreshing JWKS", kid)
-            await self._sleep()
-            self.reset_cache()
-            await self.load_config()
+        """Return the signing key for ``kid``, refreshing JWKS once per cooldown if missing.
+        The sleep is inside the try/finally so the cooldown still engages if the request
+        is canceled mid-sleep.
+        """
+        if kid in self.signing_keys:
+            return self.signing_keys[kid]
 
-            if kid not in self.signing_keys:
-                log.error(f"Unable to verify token, no signing keys found for key with ID: '{kid}'")
+        async with self.refresh_lock:
+            if kid in self.signing_keys:
+                return self.signing_keys[kid]
+
+            if self._is_throttled():
+                log.warning("JWKS refresh throttled; unknown kid '%s'", kid)
                 raise UnauthorizedException("Unable to verify token, no signing keys found")
+
+            log.debug("Key '%s' not found, waiting for Zitadel and merging JWKS", kid)
+            try:
+                await self._sleep()
+                await self._refresh_jwks_merge()
+            finally:
+                self.last_refresh_attempt = datetime.now()
+
+        if kid not in self.signing_keys:
+            log.error("Unable to verify token, no signing keys found for key with ID: '%s'", kid)
+            raise UnauthorizedException("Unable to verify token, no signing keys found")
         return self.signing_keys[kid]
 
+    def _is_throttled(self) -> bool:
+        """True if a refresh was attempted within the 10 s cooldown."""
+        if self.last_refresh_attempt is None:
+            return False
+        elapsed = datetime.now() - self.last_refresh_attempt
+        return elapsed < timedelta(seconds=10)
+
+    async def _refresh_jwks_merge(self) -> None:
+        """Fetch JWKS and merge new entries into ``signing_keys``."""
+        try:
+            async with httpx.AsyncClient(timeout=10, http2=True) as client:
+                new_keys = await self._fetch_signing_keys(client)
+            self.signing_keys = {**self.signing_keys, **new_keys}
+        except Exception as e:
+            log.exception(f"Unable to refresh JWKS from identity provider: {e}")
+            raise UnauthorizedException("Unable to refresh JWKS from identity provider")
+
     def reset_cache(self) -> None:
-        """Reset the cache by clearing the timestamp and keys."""
+        """Drop cached signing keys and the last-refresh timestamp."""
         self.last_refresh_timestamp = None
         self.signing_keys = {}
         log.debug("Reset OpenID configuration cache")
 
     @staticmethod
     async def _sleep() -> None:
-        """Wait for a short period to allow other tasks to run."""
+        """Sleep briefly to absorb Zitadel's ad-hoc keypair propagation lag."""
         log.debug("Waiting for other tasks to finish...")
         await sleep(1)
 
     def _needs_refresh(self) -> bool:
-        """Check if the cached keys should be refreshed based on cache state or time elapsed."""
+        """True when there are no cached keys or the TTL has elapsed."""
         if not self.last_refresh_timestamp or not self.signing_keys:
             return True
 
@@ -93,22 +146,22 @@ class OpenIdConfig(BaseModel):
         return elapsed > timedelta(seconds=self.cache_ttl_seconds)
 
     async def _fetch_config(self, client: httpx.AsyncClient) -> dict[str, Any]:
-        """Fetch OpenID Connect configuration."""
+        """GET the OIDC discovery document."""
         log.info("Fetching OpenID configuration from %s", self.config_url)
         response = await client.get(self.config_url)
         response.raise_for_status()
         return response.json()
 
-    async def _fetch_jwks(self, client: httpx.AsyncClient) -> dict[str, list]:
-        """Fetch JWK Set from the jwks_uri."""
+    async def _fetch_signing_keys(self, client: httpx.AsyncClient) -> dict[str, RSAPublicKey]:
+        """GET the JWKS and parse it into a ``kid → RSAPublicKey`` dict."""
         log.info("Fetching JWKS from %s", self.jwks_uri)
         response = await client.get(self.jwks_uri)
         response.raise_for_status()
-        return response.json()
+        return self._parse_jwks(response.json())
 
     @staticmethod
     def _parse_jwks(jwks: dict[str, list]) -> dict[str, RSAPublicKey]:
-        """Parse the JWKS response and return a dictionary of RSA public keys."""
+        """Filter to RS256 signing keys and return as ``kid → RSAPublicKey``."""
         keys = {}
         available_keys = jwks.get("keys", [])
         for key in available_keys:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,11 +81,10 @@ def mock_openid_empty_then_ok(respx_mock, mock_openid):
     openid_route = respx_mock.get(openid_config_url())
     openid_route.side_effect = [
         httpx.Response(json=openid_configuration(), status_code=200),
-        httpx.Response(json=openid_configuration(), status_code=200),
     ]
     yield
     assert keys_route.call_count == 2
-    assert openid_route.call_count == 2
+    assert openid_route.call_count == 1
 
 
 @pytest.fixture

--- a/tests/test_openid_config.py
+++ b/tests/test_openid_config.py
@@ -2,12 +2,43 @@
 Tests for OpenIdConfig class
 """
 
+import httpx
+import jwt
 import pytest
 from datetime import datetime, timedelta
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
+from fastapi_zitadel_auth.exceptions import UnauthorizedException
 from fastapi_zitadel_auth.openid_config import OpenIdConfig
 from tests.utils import valid_key, ZITADEL_ISSUER, openid_config_url, keys_url
+
+
+def _config_with_seeded_key(kid: str = "k1") -> OpenIdConfig:
+    """Build an OpenIdConfig pre-populated with one valid signing key."""
+    return OpenIdConfig(
+        issuer_url=ZITADEL_ISSUER,
+        config_url=openid_config_url(),
+        authorization_url=f"{ZITADEL_ISSUER}/oauth/v2/authorize",
+        token_url=f"{ZITADEL_ISSUER}/oauth/v2/token",
+        jwks_uri=keys_url(),
+        signing_keys={kid: valid_key.public_key()},
+        last_refresh_timestamp=datetime.now(),
+    )
+
+
+def _jwks_with(kid: str) -> dict:
+    """Build a JWKS response containing exactly one RS256 sig key with the given kid."""
+    return {
+        "keys": [
+            {
+                "use": "sig",
+                "kid": kid,
+                "kty": "RSA",
+                "alg": "RS256",
+                **jwt.algorithms.RSAAlgorithm.to_jwk(valid_key.public_key(), as_dict=True),
+            }
+        ]
+    }
 
 
 @pytest.fixture
@@ -175,3 +206,186 @@ class TestOpenIdConfig:
             signing_keys={"kid": signing_key} if signing_key else {},
         )
         assert config._needs_refresh() == expected
+
+
+@pytest.mark.asyncio
+class TestKidMissRefresh:
+    """Regression suite for GH #149: unknown-kid path must not DoS the worker pool."""
+
+    async def test_kid_in_cache_skips_refresh(self, respx_mock, mocker):
+        """Cached kid returns immediately, no sleep, no JWKS fetch."""
+        sleep_mock = mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        keys_route = respx_mock.get(keys_url()).respond(json=_jwks_with("any"))
+
+        config = _config_with_seeded_key("k1")
+        result = await config.get_key("k1")
+
+        assert isinstance(result, RSAPublicKey)
+        assert sleep_mock.call_count == 0
+        assert keys_route.call_count == 0
+        assert config.last_refresh_attempt is None
+
+    async def test_kid_miss_merges_keys(self, respx_mock, mocker):
+        """Unknown kid: sleep once, fetch JWKS once, merge into existing keys."""
+        sleep_mock = mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        config_route = respx_mock.get(openid_config_url())
+        keys_route = respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        config = _config_with_seeded_key("k1")
+        result = await config.get_key("k2")
+
+        assert isinstance(result, RSAPublicKey)
+        assert "k1" in config.signing_keys
+        assert "k2" in config.signing_keys
+        assert sleep_mock.call_count == 1
+        assert keys_route.call_count == 1
+        assert config_route.call_count == 0
+        assert config.last_refresh_attempt is not None
+
+    async def test_kid_miss_throttled_within_cooldown(self, respx_mock, mocker, freezer):
+        """Second unknown-kid request within 10s short-circuits to 401 with no fetch/sleep."""
+        sleep_mock = mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        keys_route = respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        freezer.move_to(t0)
+        config = _config_with_seeded_key("k1")
+
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown1")  # fetches, fails, sets last_refresh_attempt
+
+        freezer.move_to(t0 + timedelta(seconds=5))
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown2")
+
+        assert keys_route.call_count == 1
+        assert sleep_mock.call_count == 1
+
+    async def test_kid_miss_refetches_after_cooldown(self, respx_mock, mocker, freezer):
+        """After the cooldown elapses, a fresh unknown-kid miss triggers another fetch."""
+        sleep_mock = mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        keys_route = respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        freezer.move_to(t0)
+        config = _config_with_seeded_key("k1")
+
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown1")
+
+        freezer.move_to(t0 + timedelta(seconds=11))
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown2")
+
+        assert keys_route.call_count == 2
+        assert sleep_mock.call_count == 2
+
+    async def test_failed_refresh_still_updates_attempt(self, respx_mock, mocker, freezer):
+        """A 5xx from the JWKS endpoint must still set last_refresh_attempt so we don't hot-loop."""
+        sleep_mock = mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        keys_route = respx_mock.get(keys_url()).respond(status_code=500)
+
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        freezer.move_to(t0)
+        config = _config_with_seeded_key("k1")
+
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown1")
+        assert config.last_refresh_attempt == t0
+
+        freezer.move_to(t0 + timedelta(seconds=5))
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown2")
+
+        assert keys_route.call_count == 1  # second call throttled
+        assert sleep_mock.call_count == 1
+
+    async def test_kid_miss_does_not_evict_existing_keys(self, respx_mock, mocker):
+        """Merge semantics: if JWKS returns a disjoint set, original keys remain."""
+        mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        config = _config_with_seeded_key("k1")
+        original_key = config.signing_keys["k1"]
+
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("still-unknown")
+
+        assert "k1" in config.signing_keys
+        assert config.signing_keys["k1"] is original_key
+        assert "k2" in config.signing_keys
+
+    async def test_kid_miss_does_not_refetch_openid_config(self, respx_mock, mocker):
+        """Discovery endpoint URLs are stable; kid miss must only hit JWKS."""
+        mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        config_route = respx_mock.get(openid_config_url())
+        respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        config = _config_with_seeded_key("k1")
+        await config.get_key("k2")
+
+        assert config_route.call_count == 0
+
+    async def test_kid_miss_network_error_raises_unauthorized(self, respx_mock, mocker):
+        """A transport error during JWKS fetch surfaces as UnauthorizedException, not a 500."""
+        mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        respx_mock.get(keys_url()).mock(side_effect=httpx.ConnectError("boom"))
+
+        config = _config_with_seeded_key("k1")
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown")
+        assert config.last_refresh_attempt is not None
+
+    async def test_concurrent_kid_miss_only_fetches_once(self, respx_mock, mocker):
+        """Two coroutines racing on the same unknown kid: the lock + double-check
+        ensures exactly one JWKS fetch happens and both get the merged key."""
+        import asyncio
+
+        async def yielding_sleep() -> None:
+            await asyncio.sleep(0)
+
+        mocker.patch(
+            "fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep",
+            side_effect=yielding_sleep,
+        )
+        keys_route = respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        config = _config_with_seeded_key("k1")
+
+        results = await asyncio.gather(
+            config.get_key("k2"),
+            config.get_key("k2"),
+        )
+
+        assert all(isinstance(r, RSAPublicKey) for r in results)
+        assert keys_route.call_count == 1  # second coroutine hit the double-check, not the fetch
+
+    async def test_cancellation_during_sleep_engages_throttle(self, respx_mock, mocker, freezer):
+        """Regression: cancellation during _sleep (e.g. attacker closes TCP mid-handler)
+        must not bypass the cooldown throttle. The next attacker request within 10s must
+        short-circuit instead of paying another sleep+fetch."""
+        import asyncio
+
+        async def raise_cancelled() -> None:
+            raise asyncio.CancelledError()
+
+        sleep_mock = mocker.patch(
+            "fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep",
+            side_effect=raise_cancelled,
+        )
+        keys_route = respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        freezer.move_to(t0)
+        config = _config_with_seeded_key("k1")
+
+        with pytest.raises(asyncio.CancelledError):
+            await config.get_key("unknown1")
+        assert config.last_refresh_attempt == t0
+        assert keys_route.call_count == 0  # cancelled before reaching the fetch
+
+        freezer.move_to(t0 + timedelta(seconds=5))
+        with pytest.raises(UnauthorizedException):
+            await config.get_key("unknown2")
+        assert sleep_mock.call_count == 1  # second call short-circuited before any sleep
+        assert keys_route.call_count == 0

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-zitadel-auth"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -656,6 +656,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -668,6 +669,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -676,6 +678,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
Closes #149

Before this change, any unauthenticated request whose token header carried a `kid` not currently cached would:
  1. Block the handler for 1 s on `asyncio.sleep` before doing anything else.
  2. Wipe the entire `signing_keys` cache via `reset_cache()`, invalidating valid keys held for concurrent in-flight requests.
  3. Trigger a serialized refetch of the OIDC discovery document and JWKS, serialized through `refresh_lock`.

  An attacker bursting tokens with random `kid` values could pin coroutines, repeatedly evict legitimate keys, and amplify traffic to Zitadel's JWKS endpoint. 
After this change a kid-miss burst costs at most one sleep plus one upstream GET per 10s window, never evicts cached keys, and never refetches the discovery doc.