### PR TITLE
fix: reject tokens issued for sibling apps in the same Zitadel project

### DIFF
--- a/docs/fastapi-configuration.md
+++ b/docs/fastapi-configuration.md
@@ -29,6 +29,24 @@ zitadel_auth = ZitadelAuth(
         "urn:zitadel:iam:org:projects:roles": "Roles",
     }
 )
+```
+
+!!! warning "Audience and client binding"
+
+    A token is accepted only if both:
+
+    1. its `aud` claim contains the configured `app_client_id`, and
+    2. its `client_id` claim equals the configured `app_client_id`.
+
+    By default, Zitadel includes every app in a project — plus the
+    project ID — in the access token's
+    [`aud` claim](https://zitadel.com/docs/apis/openidoauth/claims#standard-claims),
+    so audience matching alone accepts tokens issued for sibling apps in
+    the same project. The `client_id` claim is the only reliable per-app
+    discriminator. See Zitadel's
+    [audience validation guidance](https://help.zitadel.com/security-best-practices-validating-audience-aud-claims-in-zitadel-access-tokens).
+
+```python
 
 
 # Create a dependency to validate that the user has the required role

--- a/docs/zitadel-setup.md
+++ b/docs/zitadel-setup.md
@@ -24,6 +24,15 @@ In your Zitadel console:
 
 4. Record the **Project Id** ("Resource Id") from the project overview. You'll need this for the `ZitadelAuth` object's `project_id` parameter.
 
+!!! warning "Multiple apps in one project"
+
+    If you run more than one application in the same Zitadel project,
+    each FastAPI service must use its own `app_client_id`. The library
+    rejects tokens issued for sibling apps, even though Zitadel's default
+    [`aud` claim](https://zitadel.com/docs/apis/openidoauth/claims#standard-claims)
+    includes every sibling's client_id and the project ID. See Zitadel's
+    [audience validation guidance](https://help.zitadel.com/security-best-practices-validating-audience-aud-claims-in-zitadel-access-tokens).
+
 ## Applications
 
 The project requires (at least) two applications:

--- a/src/fastapi_zitadel_auth/auth.py
+++ b/src/fastapi_zitadel_auth/auth.py
@@ -156,7 +156,7 @@ class ZitadelAuth(SecurityBase):
                 verified_claims = self.token_validator.verify(
                     token=access_token,
                     key=signing_key,
-                    audiences=[self.client_id, self.project_id],
+                    audiences=[self.client_id],
                     issuer=self.openid_config.issuer_url,
                     token_leeway=self.token_leeway,
                 )
@@ -184,6 +184,7 @@ class ZitadelAuth(SecurityBase):
                 raise UnauthorizedException("Unable to process token") from error
 
             else:
+                self.token_validator.validate_client_id(verified_claims, self.client_id)
                 self.token_validator.validate_scopes(verified_claims, security_scopes.scopes)
 
                 user: UserT = self.user_model(  # type: ignore

--- a/src/fastapi_zitadel_auth/token.py
+++ b/src/fastapi_zitadel_auth/token.py
@@ -16,7 +16,6 @@ class TokenValidator:
     def validate_client_id(claims: dict[str, Any], expected_client_id: str) -> bool:
         """Verify the ``client_id`` claim binds the token to the expected application."""
         token_client_id = claims.get("client_id")
-        log.debug(f"token_client_id: {token_client_id} - expected_client_id: {expected_client_id}")
         if token_client_id != expected_client_id:
             log.info(
                 "Token client_id mismatch: token=%s expected=%s",

--- a/src/fastapi_zitadel_auth/token.py
+++ b/src/fastapi_zitadel_auth/token.py
@@ -13,6 +13,20 @@ class TokenValidator:
     """Handles JWT token validation and parsing"""
 
     @staticmethod
+    def validate_client_id(claims: dict[str, Any], expected_client_id: str) -> bool:
+        """Verify the ``client_id`` claim binds the token to the expected application."""
+        token_client_id = claims.get("client_id")
+        log.debug(f"token_client_id: {token_client_id} - expected_client_id: {expected_client_id}")
+        if token_client_id != expected_client_id:
+            log.info(
+                "Token client_id mismatch: token=%s expected=%s",
+                token_client_id,
+                expected_client_id,
+            )
+            raise UnauthorizedException("Token was not issued for this application")
+        return True
+
+    @staticmethod
     def validate_scopes(claims: dict[str, Any], required_scopes: list[str] | None) -> bool:
         """
         Validates that the token has the required scopes

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -118,6 +118,51 @@ async def test_invalid_token_audience(fastapi_app, mock_openid_and_keys):
         assert response.headers["WWW-Authenticate"] == "Bearer"
 
 
+async def test_sibling_app_token_rejected(fastapi_app, mock_openid_and_keys):
+    """Regression for #150: reject tokens minted for a sibling app in the
+    same Zitadel project. Zitadel populates ``aud`` with every sibling
+    client_id by default, so audience matching alone is insufficient — the
+    ``client_id`` claim must match the configured app."""
+    sibling_token = create_test_token(
+        role="admin",
+        sibling_client_id="some-other-app-in-same-project",
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {sibling_token}"},
+    ) as ac:
+        response = await ac.get("/api/protected/admin")
+        assert response.status_code == 401
+        assert response.json() == {
+            "detail": {
+                "error": "invalid_token",
+                "message": "Token was not issued for this application",
+            }
+        }
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+async def test_sibling_app_token_does_not_leak_scope_requirement(fastapi_app, mock_openid_and_keys):
+    """Sibling-app rejection must run before scope validation so the response
+    body does not disclose which scope the route requires (same principle as
+    the #148 forgery-signature fix)."""
+    sibling_token = create_test_token(
+        scopes="not-the-real-scope",
+        sibling_client_id="some-other-app-in-same-project",
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {sibling_token}"},
+    ) as ac:
+        response = await ac.get("/api/protected/scope")
+    assert response.status_code == 401
+    body = response.text
+    assert "Missing required scope" not in body
+    assert "scope1" not in body
+
+
 async def test_no_valid_keys_for_token(fastapi_app, mock_openid_and_no_valid_keys):
     """Test that if no valid keys are found, the token cannot be decoded."""
     async with AsyncClient(

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -113,6 +113,24 @@ class TestTokenValidator:
         with pytest.raises(UnauthorizedException):
             TokenValidator.validate_scopes(claims, ["read:messages"])
 
+    @pytest.mark.parametrize(
+        "claims,expected_client_id,expected",
+        [
+            ({"client_id": "app-a"}, "app-a", True),
+            ({"client_id": "app-b"}, "app-a", pytest.raises(UnauthorizedException)),
+            ({}, "app-a", pytest.raises(UnauthorizedException)),
+            ({"client_id": None}, "app-a", pytest.raises(UnauthorizedException)),
+            ({"client_id": ""}, "app-a", pytest.raises(UnauthorizedException)),
+        ],
+    )
+    def test_validate_client_id(self, claims, expected_client_id, expected):
+        """The client_id claim must equal the configured application id."""
+        if isinstance(expected, bool):
+            assert TokenValidator.validate_client_id(claims, expected_client_id) is expected
+        else:
+            with expected:
+                TokenValidator.validate_client_id(claims, expected_client_id)
+
     def test_validate_scopes_whitespace_handling(self):
         """Test handling of various whitespace patterns in scope strings"""
         claims = {"scope": "scope1    scope2\tscope3\n\rscope4"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -152,7 +152,7 @@ def create_test_token(
     now = datetime.now()
     claims = {
         "aud": ["wrong-id"] if invalid_aud else [ZITADEL_PROJECT_ID, ZITADEL_CLIENT_ID],
-        "client_id": sibling_client_id if sibling_client_id else ZITADEL_CLIENT_ID,
+        "client_id": sibling_client_id if sibling_client_id is not None else ZITADEL_CLIENT_ID,
         "exp": int((now - timedelta(hours=1)).timestamp()) if expired else int((now + timedelta(hours=1)).timestamp()),
         "iat": int(now.timestamp()),
         "iss": "wrong-issuer" if invalid_iss else ZITADEL_ISSUER,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,12 +141,18 @@ def create_test_token(
     role: str | None = None,
     typ: str = "JWT",
     alg: str = "RS256",
+    sibling_client_id: str | None = None,
 ) -> str:
-    """Create JWT tokens for testing"""
+    """Create JWT tokens for testing.
+
+    sibling_client_id mirrors Zitadel's default for a token issued to a
+    different app in the same project: the configured API client_id still
+    appears in ``aud``, but the ``client_id`` claim points elsewhere.
+    """
     now = datetime.now()
     claims = {
         "aud": ["wrong-id"] if invalid_aud else [ZITADEL_PROJECT_ID, ZITADEL_CLIENT_ID],
-        "client_id": ZITADEL_CLIENT_ID,
+        "client_id": sibling_client_id if sibling_client_id else ZITADEL_CLIENT_ID,
         "exp": int((now - timedelta(hours=1)).timestamp()) if expired else int((now + timedelta(hours=1)).timestamp()),
         "iat": int(now.timestamp()),
         "iss": "wrong-issuer" if invalid_iss else ZITADEL_ISSUER,


### PR DESCRIPTION
  Closes #150

  `TokenValidator.verify()` was called with `audiences=[client_id, project_id]`. PyJWT treats the list as "any match", so any token issued for any app in the same Zitadel project passed.
  
  ## Impact

  For deployments that host multiple apps in one Zitadel project with role-segregated access (e.g. a public SPA and an internal admin tool, or per-role apps within one project), a user who legitimately holds a token for app B could present it to app A's API and be accepted including using app A's role check against claims minted for app B. Roles assigned per app/audience could not be relied on as a trust boundary.
  
  ## Fix

By default Zitadel expands `aud` to include every sibling app's `client_id` plus the project id (see
  [`audienceFromProjectID`](https://github.com/zitadel/zitadel/blob/main/internal/api/oidc/auth_request.go#L163-L175), [claims reference](https://zitadel.com/docs/apis/openidoauth/claims)), so app A's `client_id` is already in app B's `aud`.

  The reliable per-app discriminator is the `client_id` claim, which Zitadel sets to the *requesting* app. 

This PR narrows `aud` **and** enforces `claims["client_id"] == app_client_id`, matching Zitadel's [audience validation 
  guidance](https://help.zitadel.com/security-best-practices-validating-audience-aud-claims-in-zitadel-access-tokens).