### PR TITLE
fix: cap `token_leeway` at 30s and validate `issuer_url`

### DIFF
--- a/docs/fastapi-configuration.md
+++ b/docs/fastapi-configuration.md
@@ -46,6 +46,18 @@ zitadel_auth = ZitadelAuth(
     discriminator. See Zitadel's
     [audience validation guidance](https://help.zitadel.com/security-best-practices-validating-audience-aud-claims-in-zitadel-access-tokens).
 
+!!! info "Clock skew (`token_leeway`)"
+
+    The optional `token_leeway` parameter (seconds) is applied to the
+    `exp` / `nbf` / `iat` checks. Default `0`; the library hard-caps it
+    at `MAX_TOKEN_LEEWAY_SECONDS = 30` and raises `ValueError` for
+    higher values. [RFC 7519
+    §4.1.4/§4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4)
+    permits "some small leeway, usually no more than a few minutes",
+    but a tighter cap preserves the value of `exp` for short-lived
+    OAuth2 access tokens. Synchronise host clocks via NTP rather than
+    widening this window.
+
 ```python
 
 

--- a/docs/fastapi-configuration.md
+++ b/docs/fastapi-configuration.md
@@ -50,9 +50,8 @@ zitadel_auth = ZitadelAuth(
 
     The optional `token_leeway` parameter (seconds) is applied to the
     `exp` / `nbf` / `iat` checks. Default `0`; the library hard-caps it
-    at `MAX_TOKEN_LEEWAY_SECONDS = 30` and raises `ValueError` for
-    higher values. [RFC 7519
-    §4.1.4/§4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4)
+    at 30 seconds and raises `ValueError` for higher values.
+    [RFC 7519 §4.1.4/§4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4)
     permits "some small leeway, usually no more than a few minutes",
     but a tighter cap preserves the value of `exp` for short-lived
     OAuth2 access tokens. Synchronise host clocks via NTP rather than

--- a/src/fastapi_zitadel_auth/auth.py
+++ b/src/fastapi_zitadel_auth/auth.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 log = logging.getLogger("fastapi_zitadel_auth")
 
+# Hard ceiling for ``token_leeway`` in seconds
+MAX_TOKEN_LEEWAY_SECONDS = 30.0
+
 
 class ZitadelAuth(SecurityBase):
     """
@@ -76,7 +79,9 @@ class ZitadelAuth(SecurityBase):
                 }
 
         :param token_leeway: float
-            The tolerance time in seconds for token validation
+            Clock-skew tolerance (seconds) applied to ``exp`` / ``nbf`` /
+            ``iat``. Default 0. Must be a non-negative number; values
+            above ``MAX_TOKEN_LEEWAY_SECONDS`` (30 s) raise ``ValueError``.
 
         :param cache_ttl_seconds: int
             The time in seconds to cache the OpenID configuration
@@ -99,7 +104,16 @@ class ZitadelAuth(SecurityBase):
         self.client_id = app_client_id
         self.project_id = project_id
         self.issuer_url = str(issuer_url).rstrip("/")
-        self.token_leeway = token_leeway
+
+        if isinstance(token_leeway, bool) or not isinstance(token_leeway, (int, float)) or token_leeway < 0:
+            raise ValueError("token_leeway must be a non-negative number of seconds")
+        if token_leeway > MAX_TOKEN_LEEWAY_SECONDS:
+            raise ValueError(
+                f"token_leeway={token_leeway} exceeds the maximum of "
+                f"{MAX_TOKEN_LEEWAY_SECONDS} seconds. "
+                "Synchronize clocks via NTP instead of widening the window."
+            )
+        self.token_leeway = float(token_leeway)
 
         if not issubclass(claims_model, JwtClaims):
             raise ValueError("claims_model must be a subclass of JwtClaims")

--- a/src/fastapi_zitadel_auth/auth.py
+++ b/src/fastapi_zitadel_auth/auth.py
@@ -3,7 +3,7 @@ Authentication module for Zitadel OAuth2
 """
 
 import logging
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Annotated, Type
 
 from fastapi.exceptions import HTTPException
 from fastapi.security import OAuth2AuthorizationCodeBearer, SecurityScopes
@@ -17,7 +17,7 @@ from jwt import (
     InvalidTokenError,
     MissingRequiredClaimError,
 )
-from pydantic import HttpUrl
+from pydantic import Field, HttpUrl, TypeAdapter, ValidationError
 from starlette.requests import Request
 
 from .exceptions import UnauthorizedException, InvalidRequestException, ForbiddenException
@@ -39,6 +39,15 @@ log = logging.getLogger("fastapi_zitadel_auth")
 
 # Hard ceiling for ``token_leeway`` in seconds
 MAX_TOKEN_LEEWAY_SECONDS = 30.0
+
+# Strict mode rejects bool→float coercion; allow_inf_nan=False rejects NaN/inf.
+_TOKEN_LEEWAY_VALIDATOR: TypeAdapter[float] = TypeAdapter(
+    Annotated[float, Field(ge=0, le=MAX_TOKEN_LEEWAY_SECONDS, allow_inf_nan=False, strict=True)]
+)
+
+# Validate ``issuer_url`` shape so a typo or relative URL fails at construction time
+# rather than at the first OIDC discovery call.
+_ISSUER_URL_VALIDATOR: TypeAdapter[HttpUrl] = TypeAdapter(HttpUrl)
 
 
 class ZitadelAuth(SecurityBase):
@@ -63,7 +72,9 @@ class ZitadelAuth(SecurityBase):
         Initialize the ZitadelAuth object
 
         :param issuer_url: HttpUrl | str
-            The Zitadel issuer URL
+            The Zitadel issuer URL. Must be a valid absolute ``http`` /
+            ``https`` URL; invalid values raise ``ValueError`` at
+            construction time.
 
         :param project_id: str
             The Zitadel project ID
@@ -80,8 +91,7 @@ class ZitadelAuth(SecurityBase):
 
         :param token_leeway: float
             Clock-skew tolerance (seconds) applied to ``exp`` / ``nbf`` /
-            ``iat``. Default 0. Must be a non-negative number; values
-            above ``MAX_TOKEN_LEEWAY_SECONDS`` (30 s) raise ``ValueError``.
+            ``iat``. Default: 0. Must be a finite number in [0, 30] seconds.
 
         :param cache_ttl_seconds: int
             The time in seconds to cache the OpenID configuration
@@ -103,17 +113,21 @@ class ZitadelAuth(SecurityBase):
 
         self.client_id = app_client_id
         self.project_id = project_id
-        self.issuer_url = str(issuer_url).rstrip("/")
 
-        if isinstance(token_leeway, bool) or not isinstance(token_leeway, (int, float)) or token_leeway < 0:
-            raise ValueError("token_leeway must be a non-negative number of seconds")
-        if token_leeway > MAX_TOKEN_LEEWAY_SECONDS:
+        try:
+            validated_issuer_url = _ISSUER_URL_VALIDATOR.validate_python(issuer_url)
+        except ValidationError as e:
+            raise ValueError(f"issuer_url is invalid: {e.errors()[0]['msg']}") from e
+        self.issuer_url = str(validated_issuer_url).rstrip("/")
+
+        try:
+            self.token_leeway = _TOKEN_LEEWAY_VALIDATOR.validate_python(token_leeway)
+        except ValidationError as e:
             raise ValueError(
-                f"token_leeway={token_leeway} exceeds the maximum of "
-                f"{MAX_TOKEN_LEEWAY_SECONDS} seconds. "
-                "Synchronize clocks via NTP instead of widening the window."
-            )
-        self.token_leeway = float(token_leeway)
+                f"token_leeway is invalid: {e.errors()[0]['msg']}. "
+                f"Must be a finite number in [0, {MAX_TOKEN_LEEWAY_SECONDS}] seconds; "
+                "synchronize clocks via NTP rather than widening this window."
+            ) from e
 
         if not issubclass(claims_model, JwtClaims):
             raise ValueError("claims_model must be a subclass of JwtClaims")

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1,108 +1,69 @@
+"""Tests for the custom-claims / custom-user-model extension points."""
+
 import pytest
-from pydantic import BaseModel
 
 from fastapi_zitadel_auth import ZitadelAuth
 from fastapi_zitadel_auth.user import (
     BaseZitadelUser,
-    JwtClaims,
     DefaultZitadelClaims,
     DefaultZitadelUser,
+    JwtClaims,
 )
 from tests.utils import ZITADEL_ISSUER
 
 
 class CustomClaims(JwtClaims):
-    """Custom claims with additional fields"""
+    """Custom claims with additional fields."""
 
     custom_field: str
     role: str
 
 
 class CustomUser(BaseZitadelUser):
-    """Custom user with specific claims type"""
+    """Custom user with specific claims type."""
 
     username: str
 
 
-class InvalidClaims(BaseModel):
-    """Claims class that doesn't inherit from JwtClaims"""
-
-    some_field: str
-
-
-class InvalidUser(BaseModel):
-    """User class that doesn't inherit from BaseZitadelUser"""
-
-    some_field: str
-
-
 @pytest.fixture
 def default_auth():
-    """Fixture for default ZitadelAuth instance"""
+    """A ZitadelAuth using the library's default claims and user models."""
     return ZitadelAuth(
         issuer_url=ZITADEL_ISSUER,
         project_id="project_id",
         app_client_id="client_id",
-        allowed_scopes={
-            "openid": "OpenID Connect",
-        },
+        allowed_scopes={"openid": "OpenID Connect"},
     )
 
 
 @pytest.fixture
 def custom_auth():
-    """Fixture for ZitadelAuth with custom models"""
+    """A ZitadelAuth wired with CustomClaims and CustomUser overrides."""
     return ZitadelAuth(
         claims_model=CustomClaims,
         user_model=CustomUser,
         issuer_url=ZITADEL_ISSUER,
         project_id="project_id",
         app_client_id="client_id",
-        allowed_scopes={
-            "openid": "OpenID Connect",
-        },
+        allowed_scopes={"openid": "OpenID Connect"},
     )
 
 
-class TestZitadelAuth:
+class TestCustomModels:
+    """Custom claims / user models are wired and can be instantiated."""
+
     def test_default_initialization(self, default_auth):
-        """Test initialization with default models"""
+        """Default models are wired when no overrides are passed."""
         assert default_auth.claims_model == DefaultZitadelClaims
         assert default_auth.user_model == DefaultZitadelUser
 
     def test_custom_initialization(self, custom_auth):
-        """Test initialization with custom models"""
+        """Custom models are wired when overrides are passed."""
         assert custom_auth.claims_model == CustomClaims
         assert custom_auth.user_model == CustomUser
 
-    def test_invalid_claims_model(self):
-        """Test initialization with invalid claims model"""
-        with pytest.raises(ValueError, match="claims_model must be a subclass of JwtClaims"):
-            ZitadelAuth(
-                claims_model=InvalidClaims,  # type: ignore
-                issuer_url=ZITADEL_ISSUER,
-                project_id="project_id",
-                app_client_id="client_id",
-                allowed_scopes={
-                    "openid": "OpenID Connect",
-                },
-            )
-
-    def test_invalid_user_model(self):
-        """Test initialization with invalid user model"""
-        with pytest.raises(ValueError, match="user_model must be a subclass of BaseZitadelUser"):
-            ZitadelAuth(
-                user_model=InvalidUser,  # type: ignore
-                issuer_url=ZITADEL_ISSUER,
-                project_id="project_id",
-                app_client_id="client_id",
-                allowed_scopes={
-                    "openid": "OpenID Connect",
-                },
-            )
-
     def test_user_with_claims(self):
-        """Test creation of user with claims"""
+        """A custom user can be constructed from custom claims data."""
         claims_data = {
             "aud": "test_client",
             "client_id": "123",
@@ -121,103 +82,3 @@ class TestZitadelAuth:
         assert user.access_token == "test_token"
         assert user.username == "testuser"
         assert user.claims.custom_field == "custom_value"
-
-    def test_empty_scheme_name(self):
-        """Test initialization with empty scheme_name raises ValueError"""
-        with pytest.raises(ValueError, match="scheme_name must be a non-empty string"):
-            ZitadelAuth(
-                issuer_url=ZITADEL_ISSUER,
-                project_id="project_id",
-                app_client_id="client_id",
-                allowed_scopes={"openid": "OpenID Connect"},
-                scheme_name="",
-            )
-
-    def test_empty_description(self):
-        """Test initialization with empty description raises ValueError"""
-        with pytest.raises(ValueError, match="description must be a non-empty string"):
-            ZitadelAuth(
-                issuer_url=ZITADEL_ISSUER,
-                project_id="project_id",
-                app_client_id="client_id",
-                allowed_scopes={"openid": "OpenID Connect"},
-                description="",
-            )
-
-    def test_whitespace_scheme_name(self):
-        """Test initialization with whitespace scheme_name raises ValueError"""
-        with pytest.raises(ValueError, match="scheme_name must be a non-empty string"):
-            ZitadelAuth(
-                issuer_url=ZITADEL_ISSUER,
-                project_id="project_id",
-                app_client_id="client_id",
-                allowed_scopes={"openid": "OpenID Connect"},
-                scheme_name="   ",
-            )
-
-    def test_whitespace_description(self):
-        """Test initialization with whitespace description raises ValueError"""
-        with pytest.raises(ValueError, match="description must be a non-empty string"):
-            ZitadelAuth(
-                issuer_url=ZITADEL_ISSUER,
-                project_id="project_id",
-                app_client_id="client_id",
-                allowed_scopes={"openid": "OpenID Connect"},
-                description="   ",
-            )
-
-    def test_custom_scheme_name_and_description(self):
-        """Test initialization with custom scheme_name and description"""
-        custom_auth = ZitadelAuth(
-            issuer_url=ZITADEL_ISSUER,
-            project_id="project_id",
-            app_client_id="client_id",
-            allowed_scopes={"openid": "OpenID Connect"},
-            scheme_name="CustomAuthScheme",
-            description="Custom authentication description",
-        )
-        assert custom_auth.scheme_name == "CustomAuthScheme"
-
-
-class TestTokenLeewayValidation:
-    """Guards on ``token_leeway`` parameter of ZitadelAuth to prevent misconfiguration."""
-
-    @staticmethod
-    def _build(token_leeway):
-        return ZitadelAuth(
-            issuer_url=ZITADEL_ISSUER,
-            project_id="project_id",
-            app_client_id="client_id",
-            allowed_scopes={"openid": "OpenID Connect"},
-            token_leeway=token_leeway,
-        )
-
-    def test_default_zero_accepted(self):
-        auth = ZitadelAuth(
-            issuer_url=ZITADEL_ISSUER,
-            project_id="project_id",
-            app_client_id="client_id",
-            allowed_scopes={"openid": "OpenID Connect"},
-        )
-        assert auth.token_leeway == 0.0
-
-    def test_value_at_cap_accepted(self):
-        auth = self._build(30)
-        assert auth.token_leeway == 30.0
-
-    def test_value_above_cap_rejected(self):
-        with pytest.raises(ValueError, match="exceeds the maximum"):
-            self._build(31)
-
-    def test_negative_value_rejected(self):
-        with pytest.raises(ValueError, match="non-negative"):
-            self._build(-1)
-
-    def test_non_numeric_value_rejected(self):
-        with pytest.raises(ValueError, match="non-negative"):
-            self._build("5")  # type: ignore[arg-type]
-
-    def test_bool_value_rejected(self):
-        # bool is a subclass of int — guard against accidental True/False slipping through.
-        with pytest.raises(ValueError, match="non-negative"):
-            self._build(True)  # type: ignore[arg-type]

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -177,3 +177,47 @@ class TestZitadelAuth:
             description="Custom authentication description",
         )
         assert custom_auth.scheme_name == "CustomAuthScheme"
+
+
+class TestTokenLeewayValidation:
+    """Guards on ``token_leeway`` parameter of ZitadelAuth to prevent misconfiguration."""
+
+    @staticmethod
+    def _build(token_leeway):
+        return ZitadelAuth(
+            issuer_url=ZITADEL_ISSUER,
+            project_id="project_id",
+            app_client_id="client_id",
+            allowed_scopes={"openid": "OpenID Connect"},
+            token_leeway=token_leeway,
+        )
+
+    def test_default_zero_accepted(self):
+        auth = ZitadelAuth(
+            issuer_url=ZITADEL_ISSUER,
+            project_id="project_id",
+            app_client_id="client_id",
+            allowed_scopes={"openid": "OpenID Connect"},
+        )
+        assert auth.token_leeway == 0.0
+
+    def test_value_at_cap_accepted(self):
+        auth = self._build(30)
+        assert auth.token_leeway == 30.0
+
+    def test_value_above_cap_rejected(self):
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            self._build(31)
+
+    def test_negative_value_rejected(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            self._build(-1)
+
+    def test_non_numeric_value_rejected(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            self._build("5")  # type: ignore[arg-type]
+
+    def test_bool_value_rejected(self):
+        # bool is a subclass of int — guard against accidental True/False slipping through.
+        with pytest.raises(ValueError, match="non-negative"):
+            self._build(True)  # type: ignore[arg-type]

--- a/tests/test_init_validation.py
+++ b/tests/test_init_validation.py
@@ -141,12 +141,12 @@ class TestTokenLeewayValidation:
 
     def test_value_above_cap_rejected(self):
         """A value above the 30 s cap raises ValueError."""
-        with pytest.raises(ValueError, match="less than or equal to 30"):
+        with pytest.raises(ValueError, match="token_leeway is invalid"):
             self._build(31)
 
     def test_negative_value_rejected(self):
         """A negative value raises ValueError."""
-        with pytest.raises(ValueError, match="greater than or equal to 0"):
+        with pytest.raises(ValueError, match="token_leeway is invalid"):
             self._build(-1)
 
     def test_non_numeric_value_rejected(self):
@@ -161,17 +161,17 @@ class TestTokenLeewayValidation:
 
     def test_nan_value_rejected(self):
         """NaN is rejected by the allow_inf_nan=False constraint."""
-        with pytest.raises(ValueError, match="finite"):
+        with pytest.raises(ValueError, match="token_leeway is invalid"):
             self._build(float("nan"))
 
     def test_positive_infinity_rejected(self):
         """Positive infinity is rejected by the allow_inf_nan=False constraint."""
-        with pytest.raises(ValueError, match="finite"):
+        with pytest.raises(ValueError, match="token_leeway is invalid"):
             self._build(float("inf"))
 
     def test_negative_infinity_rejected(self):
         """Negative infinity is rejected by the allow_inf_nan=False constraint."""
-        with pytest.raises(ValueError, match="finite"):
+        with pytest.raises(ValueError, match="token_leeway is invalid"):
             self._build(float("-inf"))
 
 

--- a/tests/test_init_validation.py
+++ b/tests/test_init_validation.py
@@ -1,0 +1,214 @@
+"""Tests for ``ZitadelAuth.__init__`` parameter validation.
+
+These tests cover the constructor's defense-in-depth guards: rejecting
+mistyped scopes, missing-scheme URLs, out-of-range leeway, and other
+configuration mistakes at startup rather than at first request.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from fastapi_zitadel_auth import ZitadelAuth
+from tests.utils import ZITADEL_ISSUER
+
+
+class _InvalidClaims(BaseModel):
+    """Claims class that doesn't inherit from JwtClaims."""
+
+    some_field: str
+
+
+class _InvalidUser(BaseModel):
+    """User class that doesn't inherit from BaseZitadelUser."""
+
+    some_field: str
+
+
+class TestClaimsAndUserModel:
+    """Reject ``claims_model`` / ``user_model`` overrides that don't inherit the base classes."""
+
+    def test_invalid_claims_model(self):
+        """A claims_model not inheriting from JwtClaims raises ValueError."""
+        with pytest.raises(ValueError, match="claims_model must be a subclass of JwtClaims"):
+            ZitadelAuth(
+                claims_model=_InvalidClaims,  # type: ignore
+                issuer_url=ZITADEL_ISSUER,
+                project_id="project_id",
+                app_client_id="client_id",
+                allowed_scopes={"openid": "OpenID Connect"},
+            )
+
+    def test_invalid_user_model(self):
+        """A user_model not inheriting from BaseZitadelUser raises ValueError."""
+        with pytest.raises(ValueError, match="user_model must be a subclass of BaseZitadelUser"):
+            ZitadelAuth(
+                user_model=_InvalidUser,  # type: ignore
+                issuer_url=ZITADEL_ISSUER,
+                project_id="project_id",
+                app_client_id="client_id",
+                allowed_scopes={"openid": "OpenID Connect"},
+            )
+
+
+class TestSchemeNameAndDescription:
+    """Reject empty / whitespace-only ``scheme_name`` and ``description``."""
+
+    def test_empty_scheme_name(self):
+        """An empty scheme_name raises ValueError."""
+        with pytest.raises(ValueError, match="scheme_name must be a non-empty string"):
+            ZitadelAuth(
+                issuer_url=ZITADEL_ISSUER,
+                project_id="project_id",
+                app_client_id="client_id",
+                allowed_scopes={"openid": "OpenID Connect"},
+                scheme_name="",
+            )
+
+    def test_empty_description(self):
+        """An empty description raises ValueError."""
+        with pytest.raises(ValueError, match="description must be a non-empty string"):
+            ZitadelAuth(
+                issuer_url=ZITADEL_ISSUER,
+                project_id="project_id",
+                app_client_id="client_id",
+                allowed_scopes={"openid": "OpenID Connect"},
+                description="",
+            )
+
+    def test_whitespace_scheme_name(self):
+        """A whitespace-only scheme_name raises ValueError."""
+        with pytest.raises(ValueError, match="scheme_name must be a non-empty string"):
+            ZitadelAuth(
+                issuer_url=ZITADEL_ISSUER,
+                project_id="project_id",
+                app_client_id="client_id",
+                allowed_scopes={"openid": "OpenID Connect"},
+                scheme_name="   ",
+            )
+
+    def test_whitespace_description(self):
+        """A whitespace-only description raises ValueError."""
+        with pytest.raises(ValueError, match="description must be a non-empty string"):
+            ZitadelAuth(
+                issuer_url=ZITADEL_ISSUER,
+                project_id="project_id",
+                app_client_id="client_id",
+                allowed_scopes={"openid": "OpenID Connect"},
+                description="   ",
+            )
+
+    def test_custom_scheme_name_and_description(self):
+        """A non-empty scheme_name override is preserved on the instance."""
+        custom_auth = ZitadelAuth(
+            issuer_url=ZITADEL_ISSUER,
+            project_id="project_id",
+            app_client_id="client_id",
+            allowed_scopes={"openid": "OpenID Connect"},
+            scheme_name="CustomAuthScheme",
+            description="Custom authentication description",
+        )
+        assert custom_auth.scheme_name == "CustomAuthScheme"
+
+
+class TestTokenLeewayValidation:
+    """Guards on ``token_leeway`` to prevent misconfiguration that would weaken exp/nbf/iat."""
+
+    @staticmethod
+    def _build(token_leeway):
+        """Construct a ZitadelAuth with the supplied token_leeway and library defaults elsewhere."""
+        return ZitadelAuth(
+            issuer_url=ZITADEL_ISSUER,
+            project_id="project_id",
+            app_client_id="client_id",
+            allowed_scopes={"openid": "OpenID Connect"},
+            token_leeway=token_leeway,
+        )
+
+    def test_default_zero_accepted(self):
+        """Omitting token_leeway yields 0.0."""
+        auth = ZitadelAuth(
+            issuer_url=ZITADEL_ISSUER,
+            project_id="project_id",
+            app_client_id="client_id",
+            allowed_scopes={"openid": "OpenID Connect"},
+        )
+        assert auth.token_leeway == 0.0
+
+    def test_value_at_cap_accepted(self):
+        """The exact cap value (30 s) is accepted."""
+        auth = self._build(30)
+        assert auth.token_leeway == 30.0
+
+    def test_value_above_cap_rejected(self):
+        """A value above the 30 s cap raises ValueError."""
+        with pytest.raises(ValueError, match="less than or equal to 30"):
+            self._build(31)
+
+    def test_negative_value_rejected(self):
+        """A negative value raises ValueError."""
+        with pytest.raises(ValueError, match="greater than or equal to 0"):
+            self._build(-1)
+
+    def test_non_numeric_value_rejected(self):
+        """A non-numeric value raises ValueError."""
+        with pytest.raises(ValueError, match="token_leeway is invalid"):
+            self._build("5")  # type: ignore[arg-type]
+
+    def test_bool_value_rejected(self):
+        """A bool (subclass of int) is rejected thanks to pydantic strict mode."""
+        with pytest.raises(ValueError, match="token_leeway is invalid"):
+            self._build(True)  # type: ignore[arg-type]
+
+    def test_nan_value_rejected(self):
+        """NaN is rejected by the allow_inf_nan=False constraint."""
+        with pytest.raises(ValueError, match="finite"):
+            self._build(float("nan"))
+
+    def test_positive_infinity_rejected(self):
+        """Positive infinity is rejected by the allow_inf_nan=False constraint."""
+        with pytest.raises(ValueError, match="finite"):
+            self._build(float("inf"))
+
+    def test_negative_infinity_rejected(self):
+        """Negative infinity is rejected by the allow_inf_nan=False constraint."""
+        with pytest.raises(ValueError, match="finite"):
+            self._build(float("-inf"))
+
+
+class TestIssuerUrlValidation:
+    """Guards on ``issuer_url`` — fail at construction time, not at first OIDC discovery."""
+
+    @staticmethod
+    def _build(issuer_url):
+        """Construct a ZitadelAuth with the supplied issuer_url and library defaults elsewhere."""
+        return ZitadelAuth(
+            issuer_url=issuer_url,
+            project_id="project_id",
+            app_client_id="client_id",
+            allowed_scopes={"openid": "OpenID Connect"},
+        )
+
+    def test_valid_https_url_accepted(self):
+        """A valid https URL is preserved on the instance."""
+        auth = self._build("https://example.zitadel.cloud")
+        assert auth.issuer_url == "https://example.zitadel.cloud"
+
+    def test_trailing_slash_stripped(self):
+        """A trailing slash on the issuer URL is stripped."""
+        auth = self._build("https://example.zitadel.cloud/")
+        assert auth.issuer_url == "https://example.zitadel.cloud"
+
+    def test_url_without_scheme_rejected(self):
+        """A URL missing the http/https scheme raises ValueError."""
+        with pytest.raises(ValueError, match="issuer_url is invalid"):
+            self._build("example.zitadel.cloud")
+
+    def test_empty_string_rejected(self):
+        """An empty issuer_url raises ValueError."""
+        with pytest.raises(ValueError, match="issuer_url is invalid"):
+            self._build("")
+
+    def test_non_http_scheme_rejected(self):
+        """A non-http(s) scheme (e.g. javascript:) raises ValueError."""
+        with pytest.raises(ValueError, match="issuer_url is invalid"):
+            self._build("javascript:alert(1)")


### PR DESCRIPTION
closes #153
  
Caps `token_leeway` at 30 s in `ZitadelAuth.__init__` and rejects negatives, NaN/±inf, bools, and non-numerics so a misconfig can't weaken `exp`/`nbf`/`iat`. 

Same guard added for `issuer_url` (typos fail at construction, not at first OIDC discovery).