### PR TITLE
feat: add user-agent and connect timeout to httpx Client

### DIFF
--- a/src/fastapi_zitadel_auth/openid_config.py
+++ b/src/fastapi_zitadel_auth/openid_config.py
@@ -37,6 +37,8 @@ try:
 except Exception:  # pragma: no cover
     _USER_AGENT = "fastapi-zitadel-auth/unknown"
 
+_HTTP_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+
 
 class OpenIdConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, strict=True, extra="forbid")
@@ -61,7 +63,9 @@ class OpenIdConfig(BaseModel):
             log.debug("Loading OpenID configuration.")
             current_time = datetime.now()
             try:
-                async with httpx.AsyncClient(timeout=10, http2=True, headers={"User-Agent": _USER_AGENT}) as client:
+                async with httpx.AsyncClient(
+                    timeout=_HTTP_TIMEOUT, http2=True, headers={"User-Agent": _USER_AGENT}
+                ) as client:
                     config = await self._fetch_config(client)
                     self._validate_issuer(config)
                     signing_keys = await self._fetch_signing_keys(client)
@@ -124,7 +128,9 @@ class OpenIdConfig(BaseModel):
     async def _refresh_jwks_merge(self) -> None:
         """Fetch JWKS and merge new entries into ``signing_keys``."""
         try:
-            async with httpx.AsyncClient(timeout=10, http2=True, headers={"User-Agent": _USER_AGENT}) as client:
+            async with httpx.AsyncClient(
+                timeout=_HTTP_TIMEOUT, http2=True, headers={"User-Agent": _USER_AGENT}
+            ) as client:
                 new_keys = await self._fetch_signing_keys(client)
             self.signing_keys = {**self.signing_keys, **new_keys}
         except Exception as e:

--- a/src/fastapi_zitadel_auth/openid_config.py
+++ b/src/fastapi_zitadel_auth/openid_config.py
@@ -20,6 +20,7 @@ a freshly-issued ``kid``.
 
 from asyncio import Lock, sleep
 from datetime import datetime, timedelta
+from importlib.metadata import version as _pkg_version
 import logging
 from typing import Any
 import httpx
@@ -30,6 +31,11 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from fastapi_zitadel_auth.exceptions import UnauthorizedException
 
 log = logging.getLogger("fastapi_zitadel_auth")
+
+try:
+    _USER_AGENT = f"fastapi-zitadel-auth/{_pkg_version('fastapi-zitadel-auth')}"
+except Exception:  # pragma: no cover
+    _USER_AGENT = "fastapi-zitadel-auth/unknown"
 
 
 class OpenIdConfig(BaseModel):
@@ -55,7 +61,7 @@ class OpenIdConfig(BaseModel):
             log.debug("Loading OpenID configuration.")
             current_time = datetime.now()
             try:
-                async with httpx.AsyncClient(timeout=10, http2=True) as client:
+                async with httpx.AsyncClient(timeout=10, http2=True, headers={"User-Agent": _USER_AGENT}) as client:
                     config = await self._fetch_config(client)
                     self._validate_issuer(config)
                     signing_keys = await self._fetch_signing_keys(client)
@@ -118,7 +124,7 @@ class OpenIdConfig(BaseModel):
     async def _refresh_jwks_merge(self) -> None:
         """Fetch JWKS and merge new entries into ``signing_keys``."""
         try:
-            async with httpx.AsyncClient(timeout=10, http2=True) as client:
+            async with httpx.AsyncClient(timeout=10, http2=True, headers={"User-Agent": _USER_AGENT}) as client:
                 new_keys = await self._fetch_signing_keys(client)
             self.signing_keys = {**self.signing_keys, **new_keys}
         except Exception as e:

--- a/tests/test_openid_config.py
+++ b/tests/test_openid_config.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from fastapi_zitadel_auth.exceptions import UnauthorizedException
-from fastapi_zitadel_auth.openid_config import OpenIdConfig
+from fastapi_zitadel_auth.openid_config import _USER_AGENT, OpenIdConfig
 from tests.utils import valid_key, ZITADEL_ISSUER, openid_config_url, keys_url
 
 
@@ -209,6 +209,26 @@ class TestOpenIdConfig:
         )
         assert config._needs_refresh() == expected
 
+    async def test_user_agent_sent_on_discovery_and_jwks(self, respx_mock, mock_openid_config, mock_jwks):
+        """Outbound discovery + JWKS requests must carry a library-identifying User-Agent
+        so the IdP operator can distinguish this library's traffic (GH #154)."""
+        config_url = openid_config_url()
+        config = OpenIdConfig(
+            issuer_url=ZITADEL_ISSUER,
+            config_url=config_url,
+            authorization_url=f"{ZITADEL_ISSUER}/oauth/v2/authorize",
+            token_url=f"{ZITADEL_ISSUER}/oauth/v2/token",
+            jwks_uri=keys_url(),
+        )
+        config_route = respx_mock.get(config_url).respond(json=mock_openid_config)
+        jwks_route = respx_mock.get(mock_openid_config["jwks_uri"]).respond(json=mock_jwks)
+
+        await config.load_config()
+
+        assert _USER_AGENT.startswith("fastapi-zitadel-auth/")
+        assert config_route.calls.last.request.headers["user-agent"] == _USER_AGENT
+        assert jwks_route.calls.last.request.headers["user-agent"] == _USER_AGENT
+
     async def test_issuer_mismatch_raises(self, respx_mock, mock_jwks):
         """Per RFC 8414 §3.3, a discovery response whose `issuer` differs from the
         configured issuer_url must be rejected and must not overwrite the configured
@@ -348,6 +368,17 @@ class TestKidMissRefresh:
         assert "k1" in config.signing_keys
         assert config.signing_keys["k1"] is original_key
         assert "k2" in config.signing_keys
+
+    async def test_kid_miss_jwks_fetch_sends_user_agent(self, respx_mock, mocker):
+        """The on-demand JWKS refresh path (the abuse vector cited in GH #154) must
+        also carry the library User-Agent, not just the periodic load_config path."""
+        mocker.patch("fastapi_zitadel_auth.openid_config.OpenIdConfig._sleep")
+        keys_route = respx_mock.get(keys_url()).respond(json=_jwks_with("k2"))
+
+        config = _config_with_seeded_key("k1")
+        await config.get_key("k2")
+
+        assert keys_route.calls.last.request.headers["user-agent"] == _USER_AGENT
 
     async def test_kid_miss_does_not_refetch_openid_config(self, respx_mock, mocker):
         """Discovery endpoint URLs are stable; kid miss must only hit JWKS."""


### PR DESCRIPTION
closes #154 

- uses httpx's `connect` Timeout https://www.python-httpx.org/advanced/timeouts/
- adds a user-agent header to requests against Zitadel 