### PR TITLE
fix: accept tokens from any client in the Zitadel project

### DIFF
--- a/docs/demo-project.md
+++ b/docs/demo-project.md
@@ -1,8 +1,8 @@
 # Demo project
 
-Check out the **code folder under [demo_project](https://github.com/cleanenergyexchange/fastapi-zitadel-auth/tree/main/demo_project)** for a complete example.
+See **[demo_project](https://github.com/cleanenergyexchange/fastapi-zitadel-auth/tree/main/demo_project)** for a complete example.
 
-The demo project will show:
+The demo shows:
 
 * Authentication with Zitadel OpenID Connect
 * Role-based access control for protected endpoints
@@ -13,14 +13,14 @@ The demo project will show:
 
 ## Starting the FastAPI server
 
-* Make sure to have `dev` dependencies installed: `uv sync --group dev` (see [Contributing](./features-and-bugfixes.md)).
-* Run the demo server using `uv`:
+* Install dev dependencies: `uv sync --group dev` (see [Contributing](./features-and-bugfixes.md)).
+* Run the demo server:
 
 ```bash
 uv run demo_project/main.py
 ```
 
-* The server should start at [http://localhost:8001](http://localhost:8001).
+* The server starts at [http://localhost:8001](http://localhost:8001).
 
 ## Login
 
@@ -35,29 +35,27 @@ uv run demo_project/main.py
 
 ### User login
 
-1. Navigate to [http://localhost:8001/docs](http://localhost:8001/docs).
-2. Click on the **Authorize** button in the top right corner.
-3. Click on the **Authorize** button in the modal.
-4. You should be **redirected** to the Zitadel login page.
-5. **Log in** with your Zitadel credentials.
-6. You should be **redirected back** to the FastAPI docs page.
-7. You can now try out the endpoints in the docs page.
-8. If you encounter issues, try again in a private browsing window.
+1. Open [http://localhost:8001/docs](http://localhost:8001/docs).
+2. Click **Authorize** in the top right corner.
+3. Click **Authorize** in the modal. Zitadel's login page opens.
+4. Log in with your Zitadel credentials. You are redirected back to the docs page.
+5. Try out the endpoints.
+6. If login fails, retry in a private browsing window.
 
 
 ### Service user login
 
 
-1. **Set up a service user** as described in the [setup guide](zitadel-setup.md).
-2. **Download the private key** from Zitadel.
-3. Change the config in `demo_project/service_user.py`.
-4. Run the service user script:
+1. Set up a service user as described in the [setup guide](zitadel-setup.md).
+2. Download the private key from Zitadel.
+3. Update the config in `demo_project/service_user.py`.
+4. Run the script:
 
 ```bash
 uv run demo_project/service_user.py
 ```
 
-* You should get a response similar to this:
+Expected response:
 
 ```json
 {

--- a/docs/fastapi-configuration.md
+++ b/docs/fastapi-configuration.md
@@ -1,6 +1,6 @@
 # FastAPI setup
 
-This guide shows an example of setting up a FastAPI app with Zitadel authentication.
+Set up a FastAPI app with Zitadel authentication.
 
 
 ```python
@@ -31,31 +31,33 @@ zitadel_auth = ZitadelAuth(
 )
 ```
 
-!!! warning "Audience and client binding"
+!!! info "Which tokens does my API accept?"
 
-    A token is accepted only if both:
+    The API accepts every token issued for your Zitadel project: a token is
+    valid when its [`aud` claim](https://zitadel.com/docs/apis/openidoauth/claims#standard-claims)
+    contains your `project_id` or `app_client_id`.
 
-    1. its `aud` claim contains the configured `app_client_id`, and
-    2. its `client_id` claim equals the configured `app_client_id`.
+    - Apps in the project carry the project ID in `aud` by default.
+    - Service users add it by requesting the
+      [reserved scope](https://zitadel.com/docs/apis/openidoauth/scopes#reserved-scopes)
+      `urn:zitadel:iam:org:project:id:{project_id}:aud`.
 
-    By default, Zitadel includes every app in a project — plus the
-    project ID — in the access token's
-    [`aud` claim](https://zitadel.com/docs/apis/openidoauth/claims#standard-claims),
-    so audience matching alone accepts tokens issued for sibling apps in
-    the same project. The `client_id` claim is the only reliable per-app
-    discriminator. See Zitadel's
+    The project is the trust boundary. To keep two apps apart, put them in
+    separate projects — [roles are project-scoped](https://zitadel.com/docs/concepts/structure/projects).
+
+    To limit an endpoint to one client app, check the
+    [`client_id` claim](https://zitadel.com/docs/apis/openidoauth/claims)
+    in a dependency:
+
+    ```python
+    async def validate_client(user: DefaultZitadelUser = Depends(zitadel_auth)) -> None:
+        if user.claims.client_id != CLIENT_ID:
+            raise ForbiddenException("Token was not issued by an allowed client")
+    ```
+
+    See also Zitadel's
     [audience validation guidance](https://help.zitadel.com/security-best-practices-validating-audience-aud-claims-in-zitadel-access-tokens).
 
-!!! info "Clock skew (`token_leeway`)"
-
-    The optional `token_leeway` parameter (seconds) is applied to the
-    `exp` / `nbf` / `iat` checks. Default `0`; the library hard-caps it
-    at 30 seconds and raises `ValueError` for higher values.
-    [RFC 7519 §4.1.4/§4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4)
-    permits "some small leeway, usually no more than a few minutes",
-    but a tighter cap preserves the value of `exp` for short-lived
-    OAuth2 access tokens. Synchronise host clocks via NTP rather than
-    widening this window.
 
 ```python
 
@@ -120,7 +122,7 @@ def protected_by_scope(request: Request):
 
 ## Customizing OpenAPI documentation
 
-You can optionally customize how the authentication scheme appears in Swagger UI:
+To change how the authentication scheme appears in Swagger UI:
 
 ```python
 zitadel_auth = ZitadelAuth(
@@ -130,10 +132,6 @@ zitadel_auth = ZitadelAuth(
 )
 ```
 
-!!! info "Optional parameters"
-
-    Both `scheme_name` and `description` are optional and have sensible defaults. Only customize them if you want to change how the authentication scheme appears in your API documentation.
-
 !!! note "CORS Middleware"
 
-    For production you may need to add a [CORS middleware](https://fastapi.tiangolo.com/tutorial/cors/) to your FastAPI app.
+    Production apps may need a [CORS middleware](https://fastapi.tiangolo.com/tutorial/cors/).

--- a/docs/zitadel-setup.md
+++ b/docs/zitadel-setup.md
@@ -1,12 +1,11 @@
 # Zitadel setup guide
 
-This guide walks you through setting up Zitadel authentication for your FastAPI application.
+Set up Zitadel for your FastAPI application.
 
 !!! warning "Set up as described"
 
-    This is an opinionated setup for a demo application.
-    Follow the steps exactly as described first.
-    Adjust settings for your use case only after a successful implementation.
+    This is an opinionated demo setup.
+    Follow the steps exactly first; adjust them after it works.
 
 
 ## Project configuration
@@ -24,14 +23,17 @@ In your Zitadel console:
 
 4. Record the **Project Id** ("Resource Id") from the project overview. You'll need this for the `ZitadelAuth` object's `project_id` parameter.
 
-!!! warning "Multiple apps in one project"
+!!! info "Multiple apps in one project"
 
-    If you run more than one application in the same Zitadel project,
-    each FastAPI service must use its own `app_client_id`. The library
-    rejects tokens issued for sibling apps, even though Zitadel's default
-    [`aud` claim](https://zitadel.com/docs/apis/openidoauth/claims#standard-claims)
-    includes every sibling's client_id and the project ID. See Zitadel's
-    [audience validation guidance](https://help.zitadel.com/security-best-practices-validating-audience-aud-claims-in-zitadel-access-tokens).
+    The API accepts tokens issued to **any** app in this project. Zitadel
+    puts the project ID in every token's
+    [`aud` claim](https://zitadel.com/docs/apis/openidoauth/claims#standard-claims);
+    the project is the trust boundary.
+
+    To keep two apps apart, use separate projects —
+    [roles are project-scoped](https://zitadel.com/docs/concepts/structure/projects).
+    To limit an endpoint to one client app, check the `client_id` claim in a
+    dependency (see the FastAPI configuration guide).
 
 ## Applications
 
@@ -111,13 +113,22 @@ For more information, see [Zitadel user types](https://zitadel.com/docs/guides/m
     2. Download and secure the key file
     3. Update the key file path in `demo_project/service_user.py`
 
+!!! note "Service users and the token audience"
+
+    Service user tokens carry the service user's own `client_id`, not your
+    app's. The API accepts them when they request the
+    [reserved scope](https://zitadel.com/docs/apis/openidoauth/scopes#reserved-scopes)
+    `urn:zitadel:iam:org:project:id:{project_id}:aud`, which adds the
+    project ID to `aud`. See `demo_project/service_user.py` and Zitadel's
+    [Private Key JWT guide](https://zitadel.com/docs/guides/integrate/service-accounts/private-key-jwt).
+
 
 !!! success "Configuration complete"
 
-    By now, you should have recorded the following information:
+    You should now have:
 
-     - Project Id
-     - Issuer URL
-     - API application client Id
+     - Project Id (`project_id`)
+     - Issuer URL (`issuer_url`)
+     - User Agent application client Id (`app_client_id`)
 
-    Use these values in the FastAPI application configuration (see next steps).
+    Use these values in the FastAPI configuration (next page).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-zitadel-auth"
-version = "0.4.0"
+version = "0.5.0"
 description = "Zitadel authentication for FastAPI"
 readme = "README.md"
 authors = [

--- a/src/fastapi_zitadel_auth/auth.py
+++ b/src/fastapi_zitadel_auth/auth.py
@@ -77,10 +77,13 @@ class ZitadelAuth(SecurityBase):
             construction time.
 
         :param project_id: str
-            The Zitadel project ID
+            The Zitadel project ID. Tokens are accepted when their ``aud``
+            claim carries the project ID (or the app client ID).
 
         :param app_client_id: str
-            The Zitadel application client ID
+            The client ID of the OAuth client that obtains tokens (e.g. your
+            frontend / SPA application). It appears as the token's
+            ``client_id`` claim — it is *not* the API's own identifier.
 
         :param allowed_scopes: dict[str, str]
             The allowed scopes for the application. Key is the scope name and value is the description.
@@ -111,7 +114,12 @@ class ZitadelAuth(SecurityBase):
             Default: "Zitadel OAuth2 authentication using bearer token"
         """
 
+        if not isinstance(app_client_id, str) or not app_client_id.strip():
+            raise ValueError("app_client_id must be a non-empty string")
         self.client_id = app_client_id
+
+        if not isinstance(project_id, str) or not project_id.strip():
+            raise ValueError("project_id must be a non-empty string")
         self.project_id = project_id
 
         try:
@@ -184,7 +192,7 @@ class ZitadelAuth(SecurityBase):
                 verified_claims = self.token_validator.verify(
                     token=access_token,
                     key=signing_key,
-                    audiences=[self.client_id],
+                    audiences=[self.client_id, self.project_id],
                     issuer=self.openid_config.issuer_url,
                     token_leeway=self.token_leeway,
                 )
@@ -212,7 +220,6 @@ class ZitadelAuth(SecurityBase):
                 raise UnauthorizedException("Unable to process token") from error
 
             else:
-                self.token_validator.validate_client_id(verified_claims, self.client_id)
                 self.token_validator.validate_scopes(verified_claims, security_scopes.scopes)
 
                 user: UserT = self.user_model(  # type: ignore

--- a/src/fastapi_zitadel_auth/token.py
+++ b/src/fastapi_zitadel_auth/token.py
@@ -1,13 +1,11 @@
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import jwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from fastapi_zitadel_auth.exceptions import UnauthorizedException, ForbiddenException
 
-if TYPE_CHECKING:  # pragma: no cover
-    from jwt.types import Options
 
 log = logging.getLogger("fastapi_zitadel_auth")
 
@@ -65,7 +63,7 @@ class TokenValidator:
         token_leeway: float = 0,
     ) -> dict[str, Any]:
         """Verify token signature and claims with provided key"""
-        options: "Options" = {
+        options: jwt.types.Options = {
             "verify_signature": True,
             "verify_exp": True,
             "verify_nbf": True,

--- a/src/fastapi_zitadel_auth/token.py
+++ b/src/fastapi_zitadel_auth/token.py
@@ -1,29 +1,19 @@
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from fastapi_zitadel_auth.exceptions import UnauthorizedException, ForbiddenException
 
+if TYPE_CHECKING:  # pragma: no cover
+    from jwt.types import Options
+
 log = logging.getLogger("fastapi_zitadel_auth")
 
 
 class TokenValidator:
     """Handles JWT token validation and parsing"""
-
-    @staticmethod
-    def validate_client_id(claims: dict[str, Any], expected_client_id: str) -> bool:
-        """Verify the ``client_id`` claim binds the token to the expected application."""
-        token_client_id = claims.get("client_id")
-        if token_client_id != expected_client_id:
-            log.info(
-                "Token client_id mismatch: token=%s expected=%s",
-                token_client_id,
-                expected_client_id,
-            )
-            raise UnauthorizedException("Token was not issued for this application")
-        return True
 
     @staticmethod
     def validate_scopes(claims: dict[str, Any], required_scopes: list[str] | None) -> bool:
@@ -75,7 +65,7 @@ class TokenValidator:
         token_leeway: float = 0,
     ) -> dict[str, Any]:
         """Verify token signature and claims with provided key"""
-        options = {
+        options: "Options" = {
             "verify_signature": True,
             "verify_exp": True,
             "verify_nbf": True,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -118,49 +118,53 @@ async def test_invalid_token_audience(fastapi_app, mock_openid_and_keys):
         assert response.headers["WWW-Authenticate"] == "Bearer"
 
 
-async def test_sibling_app_token_rejected(fastapi_app, mock_openid_and_keys):
-    """Regression for #150: reject tokens minted for a sibling app in the
-    same Zitadel project. Zitadel populates ``aud`` with every sibling
-    client_id by default, so audience matching alone is insufficient — the
-    ``client_id`` claim must match the configured app."""
-    sibling_token = create_test_token(
-        role="admin",
-        sibling_client_id="some-other-app-in-same-project",
-    )
+@pytest.mark.parametrize(
+    "caller_client_id,caller_aud",
+    [
+        # the configured app itself (e.g. your SPA / Swagger UI)
+        (ZITADEL_CLIENT_ID, None),
+        # ``aud`` carries only the app client id (no project id)
+        (ZITADEL_CLIENT_ID, [ZITADEL_CLIENT_ID]),
+        # another client app in the same project (e.g. a second SPA / external client)
+        ("external-client", None),
+        # a service account: its own client_id, and ``aud`` carries only the
+        # project id (the shape produced by the jwt-bearer flow with the
+        # ``urn:zitadel:iam:org:project:id:{project_id}:aud`` scope, see #169)
+        ("service-account-xyz", [ZITADEL_PROJECT_ID]),
+        # same, with ``aud`` as a bare string (RFC 7519 permits a single-string aud)
+        ("service-account-xyz", ZITADEL_PROJECT_ID),
+    ],
+)
+async def test_project_caller_matrix(fastapi_app, mock_openid_and_keys, caller_client_id, caller_aud):
+    """Every client of the Zitadel project is accepted —
+    the configured app, sibling apps (e.g. multiple frontends / external
+    clients), and service accounts created after deployment. The project is
+    the trust boundary; tokens only need the project id (or app client id)
+    in ``aud``."""
+    access_token = create_test_token(role="admin", sibling_client_id=caller_client_id, aud=caller_aud)
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",
-        headers={"Authorization": f"Bearer {sibling_token}"},
+        headers={"Authorization": f"Bearer {access_token}"},
+    ) as ac:
+        response = await ac.get("/api/protected/admin")
+        assert response.status_code == 200, response.text
+        # the client_id claim must identify the caller: the documented
+        # per-client restriction recipe relies on user.claims.client_id
+        assert response.json()["user"]["claims"]["client_id"] == caller_client_id
+
+
+async def test_empty_audience_rejected(fastapi_app, mock_openid_and_keys):
+    """A token with an empty ``aud`` list matches no accepted audience."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": "Bearer " + create_test_token(role="admin", aud=[])},
     ) as ac:
         response = await ac.get("/api/protected/admin")
         assert response.status_code == 401
-        assert response.json() == {
-            "detail": {
-                "error": "invalid_token",
-                "message": "Token was not issued for this application",
-            }
-        }
+        assert response.json() == {"detail": {"error": "invalid_token", "message": "Token contains invalid claims"}}
         assert response.headers["WWW-Authenticate"] == "Bearer"
-
-
-async def test_sibling_app_token_does_not_leak_scope_requirement(fastapi_app, mock_openid_and_keys):
-    """Sibling-app rejection must run before scope validation so the response
-    body does not disclose which scope the route requires (same principle as
-    the #148 forgery-signature fix)."""
-    sibling_token = create_test_token(
-        scopes="not-the-real-scope",
-        sibling_client_id="some-other-app-in-same-project",
-    )
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-        headers={"Authorization": f"Bearer {sibling_token}"},
-    ) as ac:
-        response = await ac.get("/api/protected/scope")
-    assert response.status_code == 401
-    body = response.text
-    assert "Missing required scope" not in body
-    assert "scope1" not in body
 
 
 async def test_no_valid_keys_for_token(fastapi_app, mock_openid_and_no_valid_keys):

--- a/tests/test_init_validation.py
+++ b/tests/test_init_validation.py
@@ -175,6 +175,64 @@ class TestTokenLeewayValidation:
             self._build(float("-inf"))
 
 
+class TestAppClientIdValidation:
+    """Guards on ``app_client_id`` — it is an accepted audience, so it must be set."""
+
+    @staticmethod
+    def _build(app_client_id):
+        """Construct a ZitadelAuth with the supplied app_client_id and library defaults elsewhere."""
+        return ZitadelAuth(
+            issuer_url=ZITADEL_ISSUER,
+            project_id="project_id",
+            app_client_id=app_client_id,
+            allowed_scopes={"openid": "OpenID Connect"},
+        )
+
+    def test_empty_string_rejected(self):
+        """An empty app_client_id raises ValueError."""
+        with pytest.raises(ValueError, match="app_client_id must be a non-empty string"):
+            self._build("")
+
+    def test_whitespace_only_rejected(self):
+        """A whitespace-only app_client_id raises ValueError."""
+        with pytest.raises(ValueError, match="app_client_id must be a non-empty string"):
+            self._build("   ")
+
+    def test_non_string_rejected(self):
+        """A non-string app_client_id raises ValueError."""
+        with pytest.raises(ValueError, match="app_client_id must be a non-empty string"):
+            self._build(None)
+
+
+class TestProjectIdValidation:
+    """Guards on ``project_id`` — it is an accepted audience in "project" mode, so it must be set."""
+
+    @staticmethod
+    def _build(project_id):
+        """Construct a ZitadelAuth with the supplied project_id and library defaults elsewhere."""
+        return ZitadelAuth(
+            issuer_url=ZITADEL_ISSUER,
+            project_id=project_id,
+            app_client_id="client_id",
+            allowed_scopes={"openid": "OpenID Connect"},
+        )
+
+    def test_empty_string_rejected(self):
+        """An empty project_id raises ValueError."""
+        with pytest.raises(ValueError, match="project_id must be a non-empty string"):
+            self._build("")
+
+    def test_whitespace_only_rejected(self):
+        """A whitespace-only project_id raises ValueError."""
+        with pytest.raises(ValueError, match="project_id must be a non-empty string"):
+            self._build("   ")
+
+    def test_non_string_rejected(self):
+        """A non-string project_id raises ValueError."""
+        with pytest.raises(ValueError, match="project_id must be a non-empty string"):
+            self._build(123)
+
+
 class TestIssuerUrlValidation:
     """Guards on ``issuer_url`` — fail at construction time, not at first OIDC discovery."""
 

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -113,24 +113,6 @@ class TestTokenValidator:
         with pytest.raises(UnauthorizedException):
             TokenValidator.validate_scopes(claims, ["read:messages"])
 
-    @pytest.mark.parametrize(
-        "claims,expected_client_id,expected",
-        [
-            ({"client_id": "app-a"}, "app-a", True),
-            ({"client_id": "app-b"}, "app-a", pytest.raises(UnauthorizedException)),
-            ({}, "app-a", pytest.raises(UnauthorizedException)),
-            ({"client_id": None}, "app-a", pytest.raises(UnauthorizedException)),
-            ({"client_id": ""}, "app-a", pytest.raises(UnauthorizedException)),
-        ],
-    )
-    def test_validate_client_id(self, claims, expected_client_id, expected):
-        """The client_id claim must equal the configured application id."""
-        if isinstance(expected, bool):
-            assert TokenValidator.validate_client_id(claims, expected_client_id) is expected
-        else:
-            with expected:
-                TokenValidator.validate_client_id(claims, expected_client_id)
-
     def test_validate_scopes_whitespace_handling(self):
         """Test handling of various whitespace patterns in scope strings"""
         claims = {"scope": "scope1    scope2\tscope3\n\rscope4"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -142,22 +142,54 @@ def create_test_token(
     typ: str = "JWT",
     alg: str = "RS256",
     sibling_client_id: str | None = None,
+    aud: list[str] | str | None = None,
 ) -> str:
-    """Create JWT tokens for testing.
+    """Build a signed RS256 JWT shaped like a Zitadel access token.
 
-    sibling_client_id mirrors Zitadel's default for a token issued to a
-    different app in the same project: the configured API client_id still
-    appears in ``aud``, but the ``client_id`` claim points elsewhere.
+    The defaults produce a valid token: signed with the trusted test key,
+    issued by ``ZITADEL_ISSUER`` to the configured app, with
+    ``aud=[ZITADEL_PROJECT_ID, ZITADEL_CLIENT_ID]``. Each parameter sets
+    one aspect of it:
+
+    - ``expired`` / ``invalid_iss`` / ``invalid_aud``: break the respective claim.
+    - ``evil``: sign with an untrusted key while the header claims a trusted ``kid``.
+    - ``kid`` / ``typ`` / ``alg``: set the JWT header fields.
+    - ``scopes``: the space-separated ``scope`` claim.
+    - ``role``: assert a Zitadel project role.
+    - ``sibling_client_id``: set ``client_id`` to another app of the same
+      project; ``aud`` keeps its default.
+    - ``aud``: replace the audience entirely (overrides ``invalid_aud``),
+      e.g. ``[ZITADEL_PROJECT_ID]`` for a service-user token. A bare string
+      is allowed (RFC 7519 permits a single-string ``aud``).
     """
     now = datetime.now()
+    issued_at = int(now.timestamp())
+
+    expires_at = int((now + timedelta(hours=1)).timestamp())
+    if expired:
+        expires_at = int((now - timedelta(hours=1)).timestamp())
+
+    issuer = ZITADEL_ISSUER
+    if invalid_iss:
+        issuer = "wrong-issuer"
+
+    client_id = ZITADEL_CLIENT_ID
+    if sibling_client_id is not None:
+        client_id = sibling_client_id
+
+    if aud is None:
+        aud = [ZITADEL_PROJECT_ID, ZITADEL_CLIENT_ID]
+        if invalid_aud:
+            aud = ["wrong-id"]
+
     claims = {
-        "aud": ["wrong-id"] if invalid_aud else [ZITADEL_PROJECT_ID, ZITADEL_CLIENT_ID],
-        "client_id": sibling_client_id if sibling_client_id is not None else ZITADEL_CLIENT_ID,
-        "exp": int((now - timedelta(hours=1)).timestamp()) if expired else int((now + timedelta(hours=1)).timestamp()),
-        "iat": int(now.timestamp()),
-        "iss": "wrong-issuer" if invalid_iss else ZITADEL_ISSUER,
+        "aud": aud,
+        "client_id": client_id,
+        "exp": expires_at,
+        "iat": issued_at,
+        "iss": issuer,
         "sub": "user123",
-        "nbf": int(now.timestamp()),
+        "nbf": issued_at,
         "jti": "unique-token-id",
         "scope": scopes,
     }
@@ -165,8 +197,11 @@ def create_test_token(
     if role:
         claims[f"urn:zitadel:iam:org:project:{ZITADEL_PROJECT_ID}:roles"] = {role: {"role_id": ZITADEL_PRIMARY_DOMAIN}}
 
-    # For evil token use the evil key but claim it's from the valid key
-    signing_key = evil_key if evil else valid_key
+    signing_key = valid_key
+    if evil:
+        # Sign with the untrusted key while the header still claims a trusted kid
+        signing_key = evil_key
+
     headers = {"kid": kid, "typ": typ, "alg": alg}
 
     private_key = signing_key.private_bytes(

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-zitadel-auth"
-version = "0.3.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #169

Since `0.4.0`, only tokens minted by the configured `app_client_id` passed validation. APIs with multiple clients (SPA + service accounts) got `401` for all other callers.

### Changes
  
  - Audience check accepts `app_client_id` or `project_id` in `aud` (Zitadel's `...project:id:{project_id}:aud` scope). Reverting to 0.3.x behaviour.
  - Removed the `client_id` claim check. The project is the trust boundary, see Zitadel docs.
  - bump to 0.5.0

  ### Breaking change

Sibling apps in the same project are no longer rejected. To restrict, check `user.claims.client_id` in a dependency, or use a separate project.